### PR TITLE
[BUGFIX] Check for empty values

### DIFF
--- a/Classes/Networkteam/Neos/MailObfuscator/Typoscript/ConvertEmailLinksImplementation.php
+++ b/Classes/Networkteam/Neos/MailObfuscator/Typoscript/ConvertEmailLinksImplementation.php
@@ -54,6 +54,9 @@ class ConvertEmailLinksImplementation extends AbstractTypoScriptObject {
 	 */
 	public function evaluate() {
 		$text = $this->getValue();
+		if (empty($text)) {
+			return $text;
+		}
 		if (!is_string($text)) {
 			throw new Exception(sprintf('Only strings can be processed by this TypoScript object, given: "%s".', gettype($text)), 1409659552);
 		}


### PR DESCRIPTION
`NULL` causes Exception. Instead it should just return `NULL`.