### PR TITLE
Bugfix: fix regex for links with attributes after href

### DIFF
--- a/Classes/Fusion/ConvertEmailLinksImplementation.php
+++ b/Classes/Fusion/ConvertEmailLinksImplementation.php
@@ -50,7 +50,7 @@ class ConvertEmailLinksImplementation extends AbstractFusionObject
             return $text;
         }
         if (!is_string($text)) {
-            throw new Exception(sprintf('Only strings can be processed by this TypoScript object, given: "%s".', gettype($text)), 1409659552);
+            throw new Exception(sprintf('Only strings can be processed by this Fusion object, given: "%s".', gettype($text)), 1409659552);
         }
         $currentContext = $this->getRuntime()->getCurrentContext();
         $node = $currentContext['node'];

--- a/Resources/Private/Fusion/Prototype/MailObfuscator.fusion
+++ b/Resources/Private/Fusion/Prototype/MailObfuscator.fusion
@@ -18,7 +18,7 @@ prototype(Networkteam.Neos:MailObfuscator) {
     @class = 'Networkteam\\Neos\\MailObfuscator\\Fusion\\ConvertEmailLinksImplementation'
 
     patternMailTo = '/(href=")mailto:([^"]*)/'
-    patternMailDisplay = '/(href="mailto:[^"]*">)([^<]*)/'
+    patternMailDisplay = '/(href="mailto:[^>]*>)([^<]*)/'
 
     value = ${value}
     node = ${node}

--- a/Tests/Unit/Fusion/ConvertEmailLinksImplementationTest.php
+++ b/Tests/Unit/Fusion/ConvertEmailLinksImplementationTest.php
@@ -84,7 +84,7 @@ class ConvertEmailLinksImplementationTest extends UnitTestCase
         $this->assertSame($expectedText, $actualResult);
     }
 
-    public function emailTexts()
+    public function emailTexts(): array
     {
         return [
             'just some text not to touch' => [

--- a/Tests/Unit/Fusion/ConvertEmailLinksImplementationTest.php
+++ b/Tests/Unit/Fusion/ConvertEmailLinksImplementationTest.php
@@ -84,7 +84,7 @@ class ConvertEmailLinksImplementationTest extends UnitTestCase
         $this->assertSame($expectedText, $actualResult);
     }
 
-    public function emailTexts(): array
+    public function emailTexts()
     {
         return [
             'just some text not to touch' => [

--- a/Tests/Unit/Fusion/ConvertEmailLinksImplementationTest.php
+++ b/Tests/Unit/Fusion/ConvertEmailLinksImplementationTest.php
@@ -45,9 +45,9 @@ class ConvertEmailLinksImplementationTest extends UnitTestCase
      */
     protected $mockNode;
 
-    public function setUp()
+    public function setUp(): void
     {
-        $this->convertEmailLinks = $this->getAccessibleMock(ConvertEmailLinksImplementation::class, ['getValue'], [], '', false);
+        $this->convertEmailLinks = $this->getAccessibleMock(ConvertEmailLinksImplementation::class, ['fusionValue'], [], '', false);
 
         $this->mockContext = $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock();
         $this->mockContext->expects($this->any())->method('getWorkspaceName')->will($this->returnValue('live'));
@@ -63,7 +63,6 @@ class ConvertEmailLinksImplementationTest extends UnitTestCase
         $linkNameConverter->setReplacementString(' (at) ');
         $this->convertEmailLinks->_set('linkNameConverter', $linkNameConverter);
         $this->convertEmailLinks->_set('mailToHrefConverter', new Mailto2HrefObfuscatingConverter(15));
-
     }
 
     /**
@@ -72,13 +71,20 @@ class ConvertEmailLinksImplementationTest extends UnitTestCase
      */
     public function emailsAreConverted($rawText, $expectedText)
     {
-        $this->convertEmailLinks->expects($this->atLeastOnce())->method('getValue')->will($this->returnValue($rawText));
+        $this->convertEmailLinks
+            ->expects(self::atLeastOnce())
+            ->method('fusionValue')
+            ->will($this->returnValueMap([
+                ['value', $rawText],
+                ['patternMailTo', '/(href=")mailto:([^"]*)/'],
+                ['patternMailDisplay', '/(href="mailto:[^>]*>)([^<]*)/']
+            ]));
 
         $actualResult = $this->convertEmailLinks->evaluate();
         $this->assertSame($expectedText, $actualResult);
     }
 
-    public function emailTexts()
+    public function emailTexts(): array
     {
         return [
             'just some text not to touch' => [

--- a/Tests/Unit/Fusion/ConvertEmailLinksImplementationTest.php
+++ b/Tests/Unit/Fusion/ConvertEmailLinksImplementationTest.php
@@ -100,6 +100,10 @@ class ConvertEmailLinksImplementationTest extends UnitTestCase
             'email address with space at the beginning' => [
                 'Email <a href="mailto: test@example.com">test@example.com</a>',
                 'Email <a href="javascript:linkTo_UnCryptMailto(\'ithiOtmpbeat-rdb\', -15)">test (at) example.com</a>'
+            ],
+            'email address with attributes after href' => [
+                'Email <a href="mailto: test@example.com" itemprop="email">test@example.com</a>',
+                'Email <a href="javascript:linkTo_UnCryptMailto(\'ithiOtmpbeat-rdb\', -15)" itemprop="email">test (at) example.com</a>'
             ]
         ];
     }

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "type": "neos-plugin",
     "description": "A email address and link obfuscation plugin for Neos CMS",
     "require": {
-        "php": ">=7.0",
+        "php": ">=7.1",
         "neos/neos": "^3.0 || ^4.0 || ^5.0 || ^7.0"
     },
     "autoload": {


### PR DESCRIPTION
Currently the regex only works if there are no other attributes following the href attribute