### PR TITLE
feat: Created EEL Helpers to provide MailObfuscator functions in Fusion

### DIFF
--- a/Classes/Eel/MailObfuscator.php
+++ b/Classes/Eel/MailObfuscator.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Networkteam\Neos\MailObfuscator\Eel;
+
+use Neos\Eel\ProtectedContextAwareInterface;
+use Networkteam\Neos\MailObfuscator\Converter\Mailto2HrefObfuscatingConverter;
+use Networkteam\Neos\MailObfuscator\Converter\RewriteAtCharConverter;
+
+/**
+ * Eel helpers to provide MailObfuscator functions
+ */
+class MailObfuscator extends RewriteAtCharConverter implements ProtectedContextAwareInterface {
+
+    /**
+     * Convert at Character
+     *
+     * @param $email string
+     * @return string
+     */
+    public function convertAtChar($email = false) {
+        return $this->convert($email);
+    }
+
+    /**
+     * Convert Mailto to Href
+     *
+     * @param $email string
+     * @return string
+     */
+    public function convertMailto2Href($email = false) {
+        return (new Mailto2HrefObfuscatingConverter())->convert($email);
+    }
+
+    /**
+     * All methods are considered safe
+     *
+     * @param string $methodName
+     * @return boolean
+     */
+    public function allowsCallOfMethod($methodName) {
+        return true;
+    }
+}

--- a/Classes/Eel/MailObfuscator.php
+++ b/Classes/Eel/MailObfuscator.php
@@ -2,14 +2,27 @@
 
 namespace Networkteam\Neos\MailObfuscator\Eel;
 
+use Neos\Flow\Annotations as Flow;
 use Neos\Eel\ProtectedContextAwareInterface;
-use Networkteam\Neos\MailObfuscator\Converter\Mailto2HrefObfuscatingConverter;
-use Networkteam\Neos\MailObfuscator\Converter\RewriteAtCharConverter;
+use Networkteam\Neos\MailObfuscator\Converter\EmailLinkNameConverterInterface;
+use Networkteam\Neos\MailObfuscator\Converter\MailtoLinkConverterInterface;
 
 /**
  * Eel helpers to provide MailObfuscator functions
  */
-class MailObfuscator extends RewriteAtCharConverter implements ProtectedContextAwareInterface {
+class MailObfuscator implements ProtectedContextAwareInterface {
+
+    /**
+     * @var EmailLinkNameConverterInterface
+     * @Flow\Inject
+     */
+    protected $emailLinkNameConverter;
+
+    /**
+     * @var MailtoLinkConverterInterface
+     * @Flow\Inject
+     */
+    protected $mailtoLinkConverter;
 
     /**
      * Convert at Character
@@ -18,7 +31,7 @@ class MailObfuscator extends RewriteAtCharConverter implements ProtectedContextA
      * @return string
      */
     public function convertAtChar($email = false) {
-        return $this->convert($email);
+        return $this->emailLinkNameConverter->convert($email);
     }
 
     /**
@@ -28,7 +41,7 @@ class MailObfuscator extends RewriteAtCharConverter implements ProtectedContextA
      * @return string
      */
     public function convertMailto2Href($email = false) {
-        return (new Mailto2HrefObfuscatingConverter())->convert($email);
+        return $this->mailtoLinkConverter->convert($email);
     }
 
     /**

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -17,6 +17,10 @@ Neos:
       autoInclude:
         'Networkteam.Neos.MailObfuscator': true
 
+  Fusion:
+    defaultContext:
+      Networkteam.Neos.MailObfuscator: 'Networkteam\Neos\MailObfuscator\Eel\MailObfuscator'
+
 Networkteam:
   Neos:
     MailObfuscator:

--- a/README.md
+++ b/README.md
@@ -75,6 +75,23 @@ Networkteam:
       atCharReplacementString: '<img src="https://example.com/at-icon.png" alt="at" />'
 ```
 
+## EEL Helpers
+There are Eel helpers available to use MailObfuscator functions in Fusion
+
+```
+// Convert @ Character
+${Networkteam.Neos.MailObfuscator.convertAtChar('foo@example.com')}
+// returns: foo (at) example.com
+
+```
+
+```
+// Convert Mail to Href
+${Networkteam.Neos.MailObfuscator.convertMailto2Href('foo@example.com')}
+// returns javascript:linkTo_UnCryptMailto('obfuscatedEmail', -randomNumber)
+```
+
+
 ## Acknowledgments
 
 Original email address obfuscation code by [TYPO3 CMS](http://www.typo3.org).


### PR DESCRIPTION
## EEL Helpers
There are Eel helpers available to use MailObfuscator functions in Fusion

```
// Convert @ Character
${Networkteam.Neos.MailObfuscator.convertAtChar('foo@example.com')}
// returns: foo (at) example.com
```

```
// Convert Mail to Href
${Networkteam.Neos.MailObfuscator.convertMailto2Href('foo@example.com')}
// returns javascript:linkTo_UnCryptMailto('obfuscatedEmail', -randomNumber)
```

