### PR TITLE
Fix: Apply mailto anchor link parameters

### DIFF
--- a/Classes/Converter/Mailto2HrefObfuscatingConverter.php
+++ b/Classes/Converter/Mailto2HrefObfuscatingConverter.php
@@ -58,6 +58,9 @@ class Mailto2HrefObfuscatingConverter implements MailtoLinkConverterInterface
      */
     protected function encryptEmail(string $string, int $randomOffset): string
     {
+        // Decode HTML entities to ensure & is not encoded as &amp;
+        $string = html_entity_decode($string, ENT_QUOTES | ENT_HTML5);
+
         $out = '';
         // like str_rot13() but with a variable offset and a wider character range
         $len = strlen($string);

--- a/Classes/Converter/Mailto2HrefObfuscatingConverter.php
+++ b/Classes/Converter/Mailto2HrefObfuscatingConverter.php
@@ -58,9 +58,6 @@ class Mailto2HrefObfuscatingConverter implements MailtoLinkConverterInterface
      */
     protected function encryptEmail(string $string, int $randomOffset): string
     {
-        // Decode HTML entities to ensure & is not encoded as &amp;
-        $string = html_entity_decode($string, ENT_QUOTES | ENT_HTML5);
-
         $out = '';
         // like str_rot13() but with a variable offset and a wider character range
         $len = strlen($string);

--- a/Classes/Fusion/ConvertEmailLinksImplementation.php
+++ b/Classes/Fusion/ConvertEmailLinksImplementation.php
@@ -119,6 +119,7 @@ class ConvertEmailLinksImplementation extends AbstractFusionObject
      */
     public function convertMailLink($matches)
     {
+        // make sure that URL parameter dividers (`&`) are not encoded
         $email = html_entity_decode(trim($matches[2]), ENT_QUOTES | ENT_HTML5);
         $replacedHrefContent = $this->mailToHrefConverter->convert($email);
 

--- a/Classes/Fusion/ConvertEmailLinksImplementation.php
+++ b/Classes/Fusion/ConvertEmailLinksImplementation.php
@@ -119,9 +119,10 @@ class ConvertEmailLinksImplementation extends AbstractFusionObject
      */
     public function convertMailLink($matches)
     {
-        $email = trim($matches[2]);
+        $email = html_entity_decode(trim($matches[2]), ENT_QUOTES | ENT_HTML5);
         $replacedHrefContent = $this->mailToHrefConverter->convert($email);
 
-        return $matches[1] . htmlspecialchars($replacedHrefContent);
+        $uri = new \GuzzleHttp\Psr7\Uri($replacedHrefContent);
+        return $matches[1] . (string)$uri;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
     "description": "A email address and link obfuscation plugin for Neos CMS",
     "require": {
         "php": ">=7.1",
-        "neos/neos": "^3.0 || ^4.0 || ^5.0 || ^7.0 || ^8.0"
+        "neos/neos": "^3.0 || ^4.0 || ^5.0 || ^7.0 || ^8.0",
+        "guzzlehttp/guzzle": "*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The input string automatically gets HTML encoded, which results to url-parameters appended with `&`, like `&subject`, in being interpreted as `&amp;subject`. As special characters inside the url must be URL-encoded instead, this would not have any negative effect on updating as for example a subject with the content `foo & bar` was never correctly interpreted. 

IMO: I don't see the encoding of mailto link paramters as a task of this package. At least for now we should leave the URL-encoding up to the implementation. Therefore this change only handles the paramters being applied correctly and consecutively.