### PR TITLE
fix: Mail obfuscation for links including additional tags

### DIFF
--- a/Classes/Converter/Mailto2HrefObfuscatingConverter.php
+++ b/Classes/Converter/Mailto2HrefObfuscatingConverter.php
@@ -44,7 +44,7 @@ class Mailto2HrefObfuscatingConverter implements MailtoLinkConverterInterface
             $randomOffset = random_int(1, 26);
         }
 
-        return 'javascript:linkTo_UnCryptMailto(\'' . $this->encryptEmail($mailAddress, $randomOffset) . '\', -' . $randomOffset . ')';
+        return 'javascript:linkTo_UnCryptMailto(\'' . $this->encryptEmail($mailAddress, $randomOffset) . '\',-' . $randomOffset . ')';
     }
 
     /**

--- a/Classes/Fusion/ConvertEmailLinksImplementation.php
+++ b/Classes/Fusion/ConvertEmailLinksImplementation.php
@@ -109,7 +109,7 @@ class ConvertEmailLinksImplementation extends AbstractFusionObject
     {
         $replacedEmail = $this->linkNameConverter->convert(trim($matches[2]));
 
-        return $matches[1] . $replacedEmail;
+        return $matches[1] . $replacedEmail . $matches[3] ?? '';
     }
 
     /**

--- a/Resources/Private/Fusion/Prototype/MailObfuscator.fusion
+++ b/Resources/Private/Fusion/Prototype/MailObfuscator.fusion
@@ -18,7 +18,7 @@ prototype(Networkteam.Neos:MailObfuscator) {
     @class = 'Networkteam\\Neos\\MailObfuscator\\Fusion\\ConvertEmailLinksImplementation'
 
     patternMailTo = '/(href=")mailto:([^"]*)/'
-    patternMailDisplay = '|(href="mailto:[^>]*>)(.*)(<\/a>)|'
+    patternMailDisplay = '|(href="mailto:[^>]*>)(.*?)(<\/a>)|'
 
     value = ${value}
     node = ${node}

--- a/Resources/Private/Fusion/Prototype/MailObfuscator.fusion
+++ b/Resources/Private/Fusion/Prototype/MailObfuscator.fusion
@@ -18,7 +18,7 @@ prototype(Networkteam.Neos:MailObfuscator) {
     @class = 'Networkteam\\Neos\\MailObfuscator\\Fusion\\ConvertEmailLinksImplementation'
 
     patternMailTo = '/(href=")mailto:([^"]*)/'
-    patternMailDisplay = '/(href="mailto:[^>]*>)([^<]*)/'
+    patternMailDisplay = '|(href="mailto:[^>]*>)(.*)(<\/a>)|'
 
     value = ${value}
     node = ${node}

--- a/Tests/Unit/Fusion/ConvertEmailLinksImplementationTest.php
+++ b/Tests/Unit/Fusion/ConvertEmailLinksImplementationTest.php
@@ -77,14 +77,14 @@ class ConvertEmailLinksImplementationTest extends UnitTestCase
             ->will($this->returnValueMap([
                 ['value', $rawText],
                 ['patternMailTo', '/(href=")mailto:([^"]*)/'],
-                ['patternMailDisplay', '|(href="mailto:[^>]*>)(.*)(<\/a>)|']
+                ['patternMailDisplay', '|(href="mailto:[^>]*>)(.*?)(<\/a>)|']
             ]));
 
         $actualResult = $this->convertEmailLinks->evaluate();
         $this->assertSame($expectedText, $actualResult);
     }
 
-    public function emailTexts(): array
+    static public function emailTexts(): array
     {
 
         $htmlEncodedDecryptionString = htmlspecialchars('javascript:linkTo_UnCryptMailto(\'ithiOtmpbeat-rdb\',-15)', ENT_NOQUOTES);

--- a/Tests/Unit/Fusion/ConvertEmailLinksImplementationTest.php
+++ b/Tests/Unit/Fusion/ConvertEmailLinksImplementationTest.php
@@ -77,7 +77,7 @@ class ConvertEmailLinksImplementationTest extends UnitTestCase
             ->will($this->returnValueMap([
                 ['value', $rawText],
                 ['patternMailTo', '/(href=")mailto:([^"]*)/'],
-                ['patternMailDisplay', '/(href="mailto:[^>]*>)([^<]*)/']
+                ['patternMailDisplay', '|(href="mailto:[^>]*>)(.*)(<\/a>)|']
             ]));
 
         $actualResult = $this->convertEmailLinks->evaluate();
@@ -87,8 +87,8 @@ class ConvertEmailLinksImplementationTest extends UnitTestCase
     public function emailTexts(): array
     {
 
-        $htmlEncodedDecryptionString = htmlspecialchars('javascript:linkTo_UnCryptMailto(\'ithiOtmpbeat-rdb\', -15)');
-        $htmlEncodedSecondDecryptionString = htmlspecialchars('javascript:linkTo_UnCryptMailto(\'uddqpgOtmpbeat-rdb\', -15)');
+        $htmlEncodedDecryptionString = htmlspecialchars('javascript:linkTo_UnCryptMailto(\'ithiOtmpbeat-rdb\',-15)', ENT_NOQUOTES);
+        $htmlEncodedSecondDecryptionString = htmlspecialchars('javascript:linkTo_UnCryptMailto(\'uddqpgOtmpbeat-rdb\',-15)', ENT_NOQUOTES);
 
         return [
             'just some text not to touch' => [
@@ -114,6 +114,14 @@ class ConvertEmailLinksImplementationTest extends UnitTestCase
             'email address with attributes after href' => [
                 'Email <a href="mailto: test@example.com" itemprop="email">test@example.com</a>',
                 'Email <a href="' . $htmlEncodedDecryptionString . '" itemprop="email">test (at) example.com</a>'
+            ],
+            'email address enclosed by HTML tag' => [
+                'Email <a href="mailto: test@example.com" itemprop="email"><strong>test@example.com</strong></a>',
+                'Email <a href="' . $htmlEncodedDecryptionString . '" itemprop="email"><strong>test (at) example.com</strong></a>'
+            ],
+            'email address in link tag enclosed by multiple styling tags' => [
+                'Email <a href="mailto: test@example.com" itemprop="email"><i class="fa-light fa-paper-plane"></i><span class="btn__text">test@example.com</span></a>',
+                'Email <a href="' . $htmlEncodedDecryptionString . '" itemprop="email"><i class="fa-light fa-paper-plane"></i><span class="btn__text">test (at) example.com</span></a>'
             ]
         ];
     }


### PR DESCRIPTION
In a link tag with "mailto" href containing additional tags, such as `<strong>...</strong>`, the email address was not obfuscated.

closes #30