### PR TITLE
fix: matching newline chars inside link tag

### DIFF
--- a/Classes/Fusion/ConvertEmailLinksImplementation.php
+++ b/Classes/Fusion/ConvertEmailLinksImplementation.php
@@ -107,9 +107,10 @@ class ConvertEmailLinksImplementation extends AbstractFusionObject
      */
     public function convertLinkName(array $matches)
     {
-        $replacedEmail = $this->linkNameConverter->convert(trim($matches[2]));
-
-        return $matches[1] . $replacedEmail . ($matches[3] ?? '');
+        $lastMatch = array_pop($matches);
+        $linkNameMatch = trim($matches[2]);
+        $replacedEmail = $this->linkNameConverter->convert($linkNameMatch);
+        return $matches[1] . $replacedEmail . ($lastMatch ?? '');
     }
 
     /**

--- a/Tests/Unit/Fusion/ConvertEmailLinksImplementationTest.php
+++ b/Tests/Unit/Fusion/ConvertEmailLinksImplementationTest.php
@@ -77,7 +77,7 @@ class ConvertEmailLinksImplementationTest extends UnitTestCase
             ->will($this->returnValueMap([
                 ['value', $rawText],
                 ['patternMailTo', '/(href=")mailto:([^"]*)/'],
-                ['patternMailDisplay', '|(href="mailto:[^>]*>)(.*?)(<\/a>)|']
+                ['patternMailDisplay', '/(href="mailto:[^>]*>)((.|\n)*?)(<\/a>)/']
             ]));
 
         $actualResult = $this->convertEmailLinks->evaluate();
@@ -122,6 +122,14 @@ class ConvertEmailLinksImplementationTest extends UnitTestCase
             'email address in link tag enclosed by multiple styling tags' => [
                 'Email <a href="mailto: test@example.com" itemprop="email"><i class="fa-light fa-paper-plane"></i><span class="btn__text">test@example.com</span></a>',
                 'Email <a href="' . $htmlEncodedDecryptionString . '" itemprop="email"><i class="fa-light fa-paper-plane"></i><span class="btn__text">test (at) example.com</span></a>'
+            ],
+            'email address in link tag enclosed by multiple styling tags and new line characters' => [
+                'Email <a href="mailto: test@example.com" itemprop="email">
+    <i class="fa-light fa-paper-plane"></i>
+    <span class="btn__text">test@example.com</span>
+</a>',
+                'Email <a href="' . $htmlEncodedDecryptionString . '" itemprop="email"><i class="fa-light fa-paper-plane"></i>
+    <span class="btn__text">test (at) example.com</span></a>'
             ]
         ];
     }

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,9 @@
         "neos/neos": "^3.0 || ^4.0 || ^5.0 || ^7.0 || ^8.0",
         "guzzlehttp/guzzle": "*"
     },
+    "require-dev": {
+        "phpunit/phpunit": "~9.1"
+    },
     "autoload": {
         "psr-4": {
             "Networkteam\\Neos\\MailObfuscator\\": "Classes"


### PR DESCRIPTION
I extended the mail display pattern to match link tag containing newline characters.